### PR TITLE
Change to only look at latest commit from env directory

### DIFF
--- a/gitops/deploy/deploy.yaml
+++ b/gitops/deploy/deploy.yaml
@@ -124,7 +124,7 @@ jobs:
                     exit 1
                   fi
 
-                  COMMIT_ID=$(git rev-parse HEAD)
+                  COMMIT_ID=$(git rev-list -1 HEAD -- $ENV)
 
                   set +e
                   RESULT=$(flux-status-cli --instance ${ENV} --action workload  --git-url ${REPO_URI} --azdo-pat ${TOKEN} --commit-id ${COMMIT_ID})


### PR DESCRIPTION
Instead of looking at HEAD it is more reasonable to look at the last commit to the environments directory. This is because flux will not trigger sync events if no files have changed. This will allow dealing with situations where multiple environments are changed while changes are waited for.