### PR TITLE
Skip checkout in cd_trigger

### DIFF
--- a/gitops/build/main.yaml
+++ b/gitops/build/main.yaml
@@ -148,6 +148,7 @@ stages:
             vmImage: ${{ parameters.poolVmImage }}
         continueOnError: false
         steps:
+          - checkout: none
           - bash: |
               echo "Running this to have something for cd to trigger on if not Pull Request."
             displayName: "cd_trigger"


### PR DESCRIPTION
This shaves off a few seconds on the step, but more importantly we skip work that we don't need