### PR TITLE
Expand examples link manually

### DIFF
--- a/gitops-v2/README.md
+++ b/gitops-v2/README.md
@@ -34,7 +34,7 @@ The tenant directory contains the entrypoint for the tenant into each cluster. F
 individual `Kustomization` resources are created to deploy applications. The directory `apps` represents a group of applications,
 a tenant repository can contain multiple groups which will run their promotion in separate cadences.
 
-Look in the [examples directory](./examples/template-repository) for a template directory structure to get started.
+Look in the [examples directory](https://github.com/XenitAB/azure-devops-templates/blob/main/gitops-v2/examples/template-repository) for a template directory structure to get started.
 
 # Background
 


### PR DESCRIPTION
The relative link is broken in the downstream docs repo because it tries to expand it to a file that doesn't exist

