### PR TITLE
Stop chowning in terraform-docker

### DIFF
--- a/terraform-docker/README.md
+++ b/terraform-docker/README.md
@@ -130,46 +130,6 @@ stages:
       awsArn: arn:aws:iam::aws:policy/RandomBuiltInPolicy
 ```
 
-### Makefile
+### Packaged Terraform tooling
 
-```makefile
-SHELL:=/bin/bash
-
-SUFFIX="tfstate<4 random digits>"
-IMAGE="ghcr.io/xenitab/github-actions/tools:2021.05.2"
-ENV?=""
-DIR?=""
-OPA_BLAST_RADIUS := $(if $(OPA_BLAST_RADIUS), $(OPA_BLAST_RADIUS), 50)
-AZURE_CONFIG_DIR := $(if $(AZURE_CONFIG_DIR), $(AZURE_CONFIG_DIR), "$${HOME}/.azure")
-
-check:
-ifeq ($(ENV),"")
-	echo "Need to set ENV"
-	exit 1
-endif
-ifeq ($(DIR),"")
-	echo "Need to set DIR"
-	exit 1
-endif
-
-plan: check
-	docker run --entrypoint "/opt/terraform.sh" -e AWS_PROFILE=$${AWS_PROFILE} -v $${PWD}/$(DIR)/.terraform/$(ENV).env:/tmp/$(ENV).env -v $(AZURE_CONFIG_DIR):/home/tools/.azure -v $${AWS_CONFIG_FILE}:/home/tools/.aws/config -v $${AWS_SHARED_CREDENTIALS_FILE}:/home/tools/.aws/credentials -v $${PWD}/$(DIR):/tmp/$(DIR) -v $${PWD}/global.tfvars:/tmp/global.tfvars $(IMAGE) plan $(DIR) $(ENV) $(SUFFIX) $(OPA_BLAST_RADIUS)
-
-apply: check
-	docker run --entrypoint "/opt/terraform.sh" -e AWS_PROFILE=$${AWS_PROFILE} -v $${PWD}/$(DIR)/.terraform/$(ENV).env:/tmp/$(ENV).env -v $(AZURE_CONFIG_DIR):/home/tools/.azure -v $${AWS_CONFIG_FILE}:/home/tools/.aws/config -v $${AWS_SHARED_CREDENTIALS_FILE}:/home/tools/.aws/credentials -v $${PWD}/$(DIR):/tmp/$(DIR) -v $${PWD}/global.tfvars:/tmp/global.tfvars $(IMAGE) apply $(DIR) $(ENV) $(SUFFIX)
-
-prepare: check
-	docker run --entrypoint "/opt/terraform.sh" -e AWS_PROFILE=$${AWS_PROFILE} -v $${PWD}/$(DIR)/.terraform/$(ENV).env:/tmp/$(ENV).env -v $(AZURE_CONFIG_DIR):/home/tools/.azure -v $${AWS_CONFIG_FILE}:/home/tools/.aws/config -v $${AWS_SHARED_CREDENTIALS_FILE}:/home/tools/.aws/credentials -v $${PWD}/$(DIR):/tmp/$(DIR) -v $${PWD}/global.tfvars:/tmp/global.tfvars $(IMAGE) prepare $(DIR) $(ENV) $(SUFFIX)
-
-destroy: check
-	docker run -it --entrypoint "/opt/terraform.sh" -e AWS_PROFILE=$${AWS_PROFILE} -v $${PWD}/$(DIR)/.terraform/$(ENV).env:/tmp/$(ENV).env -v $(AZURE_CONFIG_DIR):/home/tools/.azure -v $${AWS_CONFIG_FILE}:/home/tools/.aws/config -v $${AWS_SHARED_CREDENTIALS_FILE}:/home/tools/.aws/credentials -v $${PWD}/$(DIR):/tmp/$(DIR) -v $${PWD}/global.tfvars:/tmp/global.tfvars $(IMAGE) destroy $(DIR) $(ENV) $(SUFFIX)
-
-state-remove: check
-	docker run -it --entrypoint "/opt/terraform.sh" -e AWS_PROFILE=$${AWS_PROFILE} -v $${PWD}/$(DIR)/.terraform/$(ENV).env:/tmp/$(ENV).env -v $(AZURE_CONFIG_DIR):/home/tools/.azure -v $${AWS_CONFIG_FILE}:/home/tools/.aws/config -v $${AWS_SHARED_CREDENTIALS_FILE}:/home/tools/.aws/credentials -v $${PWD}/$(DIR):/tmp/$(DIR) -v $${PWD}/global.tfvars:/tmp/global.tfvars $(IMAGE) state-remove $(DIR) $(ENV) $(SUFFIX)
-
-validate: check
-	docker run --entrypoint "/opt/terraform.sh" -e AWS_PROFILE=$${AWS_PROFILE} -v $${PWD}/$(DIR)/.terraform/$(ENV).env:/tmp/$(ENV).env -v $(AZURE_CONFIG_DIR):/home/tools/.azure -v $${AWS_CONFIG_FILE}:/home/tools/.aws/config -v $${AWS_SHARED_CREDENTIALS_FILE}:/home/tools/.aws/credentials -v $${PWD}/$(DIR):/tmp/$(DIR) -v $${PWD}/global.tfvars:/tmp/global.tfvars $(IMAGE) validate $(DIR) $(ENV) $(SUFFIX)
-
-fmt: check
-	docker run --entrypoint "/opt/terraform.sh" -e AWS_PROFILE=$${AWS_PROFILE} -v $${PWD}/$(DIR)/.terraform/$(ENV).env:/tmp/$(ENV).env -v $(AZURE_CONFIG_DIR):/home/tools/.azure -v $${AWS_CONFIG_FILE}:/home/tools/.aws/config -v $${AWS_SHARED_CREDENTIALS_FILE}:/home/tools/.aws/credentials -v $${PWD}/$(DIR):/tmp/$(DIR) -v $${PWD}/global.tfvars:/tmp/global.tfvars $(IMAGE) "fmt -recursive" $(DIR) $(ENV) $(SUFFIX)
-```
+In order to simplify the interaction with Terraform, you may want to use [XenitAB tools](https://github.com/XenitAB/github-actions). In particular, this provides an interface that can be used by both humans and CIs.

--- a/terraform-docker/apply/main.yaml
+++ b/terraform-docker/apply/main.yaml
@@ -61,55 +61,6 @@ stages:
                         artifact: "${{ env.name }}.enc"
                         path: $(Build.Repository.LocalPath)/${{ parameters.terraformFolder }}/.terraform/plans
 
-                    - task: AmazonWebServices.aws-vsts-tools.AWSShellScript.AWSShellScript@1
-                      displayName: "Get AWS credentials"
-                      inputs:
-                        workingDirectory: "."
-                        awsCredentials: ${{ format(parameters.awsServiceConnectionTemplate, env.name) }}
-                        regionName: ${{ parameters.awsRegion }}
-                        scriptType: inline
-                        inlineScript: |
-                          set -e
-                          AWS_CONFIG_FILE=${HOME}/.aws/config
-                          AWS_SHARED_CREDENTIALS_FILE=${HOME}/.aws/credentials
-                          TMPFILE=${HOME}/.aws/tmp.json
-                          mkdir -p $(dirname $TMPFILE)
-                          aws sts get-federation-token --name xkf-$ENV --policy-arns arn="$AWS_ARN" --region $AWS_REGION > $TMPFILE
-
-                          KEY_ID=$(cat $TMPFILE |jq -r .Credentials.AccessKeyId)
-                          KEY_SECRET=$(cat $TMPFILE |jq -r .Credentials.SecretAccessKey)
-                          SESSION_TOKEN=$(cat $TMPFILE |jq -r .Credentials.SessionToken)
-
-                          # Create the credentials file from AWS session token
-                          cat <<EOF > $AWS_SHARED_CREDENTIALS_FILE
-                          [xkf-$ENV]
-                          aws_access_key_id = $KEY_ID
-                          aws_secret_access_key = $KEY_SECRET
-                          aws_session_token = $SESSION_TOKEN
-
-                          EOF
-
-                          # Create the config file
-
-                          cat <<EOF > $AWS_CONFIG_FILE
-                          [default]
-                          region = $AWS_REGION
-                          output = json
-
-                          [profile xkf-$ENV]
-                              source_profile = xkf-$ENV
-                              role_arn = $AWS_ARN
-
-                          EOF
-
-                          sudo chown -R 1000:1000 ${AWS_CONFIG_FILE}
-                          sudo chown -R 1000:1000 ${AWS_SHARED_CREDENTIALS_FILE}
-                      env:
-                        AWS_REGION: ${{ parameters.awsRegion }}
-                        ENV: ${{ env.name }}
-                        AWS_ARN: ${{ parameters.awsArn }}
-                      condition: ne('${{ parameters.awsRegion }}', '')
-
                     - task: AzureCLI@1
                       displayName: "Apply"
                       inputs:

--- a/terraform-docker/apply/main.yaml
+++ b/terraform-docker/apply/main.yaml
@@ -129,25 +129,8 @@ stages:
                           echo ARM_CLIENT_SECRET=${servicePrincipalKey} >> ${PWD}/${DIR}/.terraform/${ENV}.env
                           echo ARM_TENANT_ID=${tenantId} >> ${PWD}/${DIR}/.terraform/${ENV}.env
                           echo ARM_SUBSCRIPTION_ID=$(az account show -o tsv --query 'id') >> ${PWD}/${DIR}/.terraform/${ENV}.env
-                          set +e
-                          sudo chown -R 1000:1000 ${PWD}/${DIR}
-                          sudo chown -R 1000:1000 ${AZURE_CONFIG_DIR}
-                          sudo chown -R 1000:1000 ${PWD}/global.tfvars
 
                           make apply
-                          ERROR_CODE=$?
-
-                          # post-azdo
-                          sudo chown -R $(id -u):$(id -g) ${PWD}/${DIR}
-                          sudo chown -R $(id -u):$(id -g) ${AZURE_CONFIG_DIR}
-                          sudo chown -R $(id -u):$(id -g) ${PWD}/global.tfvars
-
-                          if [[ AWS_REGION != "" ]]
-                          then
-                            sudo chown -R $(id -u):$(id -g) $(dirname ${AWS_SHARED_CREDENTIALS_FILE})
-                          fi
-
-                          exit $ERROR_CODE
                       env:
                         DIR: ${{ parameters.terraformFolder }}
                         ENV: ${{ env.name }}

--- a/terraform-docker/plan/main.yaml
+++ b/terraform-docker/plan/main.yaml
@@ -117,10 +117,6 @@ stages:
                     echo ARM_TENANT_ID=${tenantId} >> ${PWD}/${DIR}/.terraform/${ENV}.env
                     echo ARM_SUBSCRIPTION_ID=$(az account show -o tsv --query 'id') >> ${PWD}/${DIR}/.terraform/${ENV}.env
                     set +e
-                    sudo chown -R 1000:1000 ${PWD}/${DIR}
-                    sudo chown -R 1000:1000 ${AZURE_CONFIG_DIR}
-                    sudo chown -R 1000:1000 ${PWD}/global.tfvars
-
                     PREPARE_ERROR_CODE=0
                     make prepare
                     PREPARE_ERROR_CODE=$?
@@ -144,15 +140,6 @@ stages:
                     fi
 
                     # post-azdo
-                    sudo chown -R $(id -u):$(id -g) ${PWD}/${DIR}
-                    sudo chown -R $(id -u):$(id -g) ${AZURE_CONFIG_DIR}
-                    sudo chown -R $(id -u):$(id -g) ${PWD}/global.tfvars
-
-                    if [[ AWS_REGION != "" ]]
-                    then
-                      sudo chown -R $(id -u):$(id -g) $(dirname ${AWS_SHARED_CREDENTIALS_FILE})
-                    fi
-
                     if [[ ${PREPARE_ERROR_CODE} != 0 ]]; then
                       echo "ERROR: PREPARE failed."
                       exit ${PREPARE_ERROR_CODE}

--- a/terraform-docker/plan/main.yaml
+++ b/terraform-docker/plan/main.yaml
@@ -41,55 +41,6 @@ stages:
               ${{ if not(eq(parameters.poolVmImage, '')) }}:
                 vmImage: ${{ parameters.poolVmImage }}
             steps:
-              - task: AmazonWebServices.aws-vsts-tools.AWSShellScript.AWSShellScript@1
-                displayName: "Get AWS credentials"
-                inputs:
-                  workingDirectory: "."
-                  awsCredentials: ${{ format(parameters.awsServiceConnectionTemplate, env.name) }}
-                  regionName: ${{ parameters.awsRegion }}
-                  scriptType: inline
-                  inlineScript: |
-                    set -e
-                    AWS_CONFIG_FILE=${HOME}/.aws/config
-                    AWS_SHARED_CREDENTIALS_FILE=${HOME}/.aws/credentials
-                    TMPFILE=${HOME}/.aws/tmp.json
-                    mkdir -p $(dirname $TMPFILE)
-                    aws sts get-federation-token --name xkf-$ENV --policy-arns arn="$AWS_ARN" --region $AWS_REGION > $TMPFILE
-
-                    KEY_ID=$(cat $TMPFILE |jq -r .Credentials.AccessKeyId)
-                    KEY_SECRET=$(cat $TMPFILE |jq -r .Credentials.SecretAccessKey)
-                    SESSION_TOKEN=$(cat $TMPFILE |jq -r .Credentials.SessionToken)
-
-                    # Create the credentials file from AWS session token
-                    cat <<EOF > $AWS_SHARED_CREDENTIALS_FILE
-                    [xkf-$ENV]
-                    aws_access_key_id = $KEY_ID
-                    aws_secret_access_key = $KEY_SECRET
-                    aws_session_token = $SESSION_TOKEN
-
-                    EOF
-
-                    # Create the config file
-
-                    cat <<EOF > $AWS_CONFIG_FILE
-                    [default]
-                    region = $AWS_REGION
-                    output = json
-
-                    [profile xkf-$ENV]
-                        source_profile = xkf-$ENV
-                        role_arn = $AWS_ARN
-
-                    EOF
-
-                    sudo chown -R 1000:1000 ${AWS_CONFIG_FILE}
-                    sudo chown -R 1000:1000 ${AWS_SHARED_CREDENTIALS_FILE}
-                env:
-                  AWS_REGION: ${{ parameters.awsRegion }}
-                  ENV: ${{ env.name }}
-                  AWS_ARN: ${{ parameters.awsArn }}
-                condition: ne('${{ parameters.awsRegion }}', '')
-
               - task: AzureCLI@1
                 inputs:
                   azureSubscription: ${{ format(parameters.azureSubscriptionTemplate, env.name) }}


### PR DESCRIPTION
https://github.com/XenitAB/github-actions/pull/28 does away with requiring a specific user, instead assuming `docker run --user $(id -u)`. This is expected to be managed within the Makefile and obviates the need for `chown`:ing.