### PR TITLE
Fix gitops-v2 with correct environment & parameter

### DIFF
--- a/gitops-v2/new/push.yaml
+++ b/gitops-v2/new/push.yaml
@@ -106,7 +106,7 @@ jobs:
           - template: push_aws.yaml
             parameters:
               awsRegion: ${{ parameters.awsRegion }}
-              awsServiceConnection: ${{ format(parameters.awsServiceConnectionTemplate, env.name) }}
+              awsServiceConnection: ${{ format(parameters.awsServiceConnection, parameters.environment) }}
 
       - bash: |
           set -e


### PR DESCRIPTION
This PR fixes the following error:
```.txt
/gitops-v2/new/push.yaml@templates (Line: 109, Col: 37): Unrecognized value: 'env'. Located at position 49 within expression: format(parameters.awsServiceConnectionTemplate, env.name). For more help, refer to https://go.microsoft.com/fwlink/?linkid=842996
```

It also uses awsServiceConnection instead of awsServiceConnectionTemplates which is the parameter that push_aws is expecting.