### PR TITLE
Update az cli to 2.30.0

### DIFF
--- a/.github/workflows/terraform-docker.yaml
+++ b/.github/workflows/terraform-docker.yaml
@@ -113,7 +113,7 @@ jobs:
         env:
           ENV: ${{ matrix.environments.name }}
         with:
-          azcliversion: 2.0.72
+          azcliversion: 2.30.0
           inlineScript: |
             az logout
             az cache purge
@@ -171,7 +171,7 @@ jobs:
         env:
           ENV: ${{ matrix.environments.name }}
         with:
-          azcliversion: 2.0.72
+          azcliversion: 2.30.0
           inlineScript: |
             az logout
             az cache purge


### PR DESCRIPTION
AZ cli have update auth solution and want to use the same version
as the az login action does, right now always latest.
Currently it's not possible to define what version to use in az login