### PR TITLE
Fix permissions for workflow

### DIFF
--- a/.github/workflows/push-image-acr.yaml
+++ b/.github/workflows/push-image-acr.yaml
@@ -1,4 +1,4 @@
-name: terraform
+name: Build and push new image
 
 on:
   workflow_call:

--- a/.github/workflows/terraform-docker.yaml
+++ b/.github/workflows/terraform-docker.yaml
@@ -1,4 +1,4 @@
-name: terraform
+name: Plan and apply Terraform configuration
 
 on:
   workflow_call:

--- a/.github/workflows/update-azure-devops-templates-from-upstream.yaml
+++ b/.github/workflows/update-azure-devops-templates-from-upstream.yaml
@@ -18,6 +18,9 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          # we need to use a PAT with access to "workflows" since
+          # updates when fetching the repo could include changes to workflows
+          token: ${{ secrets.UPDATE_FROM_UPSTREAM_PAT }}
       - run: |
           set -e
           git checkout main

--- a/.github/workflows/update-azure-devops-templates-from-upstream.yaml
+++ b/.github/workflows/update-azure-devops-templates-from-upstream.yaml
@@ -23,7 +23,6 @@ jobs:
           token: ${{ secrets.UPDATE_FROM_UPSTREAM_PAT }}
       - run: |
           set -e
-          git checkout main
           git remote add upstream https://github.com/XenitAB/azure-devops-templates
           git pull upstream main --rebase
           git push origin main

--- a/.github/workflows/update-azure-devops-templates-from-upstream.yaml
+++ b/.github/workflows/update-azure-devops-templates-from-upstream.yaml
@@ -11,6 +11,12 @@ jobs:
   update-from-upstream:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        uses: tibdex/github-app-token@v1
+        id: generate_token
+        with:
+          app_id: ${{ secrets.UPDATE_FROM_UPSTREAM_APP_ID }}
+          private_key: ${{ secrets.UPDATE_FROM_UPSTREAM_PRIVATE_KEY }}
       - name: Update from upstream
         uses: actions/checkout@v2
         # this makes no sense to run on the main repository, and it might not even work there
@@ -18,9 +24,7 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          # we need to use a PAT with access to "workflows" since
-          # updates when fetching the repo could include changes to workflows
-          token: ${{ secrets.UPDATE_FROM_UPSTREAM_PAT }}
+          token: ${{ steps.generate_token.outputs.token }}
       - run: |
           set -e
           git remote add upstream https://github.com/XenitAB/azure-devops-templates

--- a/README.md
+++ b/README.md
@@ -68,9 +68,14 @@ Begin by [importing the repository](https://github.com/new/import) into a global
 
 #### Keeping the repository up to date
 
-The repository contains a GitHub Action that will automatically run and update the `main` branch from upstream at least once per hour, see [`./.github/workflows/update-azure-devops-templates-from-upstream.yaml`](https://github.com/XenitAB/azure-devops-templates/blob/main/.github/workflows/update-azure-devops-templates-from-upstream.yaml).
+The repository contains a GitHub Action that will automatically run and update the `main` branch from upstream at least once per hour, see [`./.github/workflows/update-azure-devops-templates-from-upstream.yaml`](https://github.com/XenitAB/azure-devops-templates/blob/main/.github/workflows/update-azure-devops-templates-from-upstream.yaml). It is not required to use this (you can keep the `main` branch up to date manually if you prefer), but it is recommended.
 
-In order for this to run correctly, you need add a secret to your clone called `UPDATE_FROM_UPSTREAM_PAT`. This secret needs to be a Personal Access Token (PAT) with access to the `workflow` scope. For information on how to create a PAT [see here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). For more information about how to add a secret, [see here](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
+In order for this to run correctly, you need to register a new (or reuse an existing) GitHub App **private to your organization** with the appropriate access. To do this, [go here](https://github.com/settings/apps/new). It is important that the app has read and write access to `contents` and `workflows`.
+
+As you register your app, you will receive an _application id_ and a _private key_. These need to be added to the secrets for your repository:
+
+- Add the _application id_ as a secret named `UPDATE_FROM_UPSTREAM_APP_ID` (this will look something like `152762`)
+- Add the _private key_ as a secret named `UPDATE_FROM_UPSTREAM_PRIVATE_KEY` (this is the contents of the `.pem` file , which starts with `-----BEGIN RSA PRIVATE KEY-----` and runs over several lines)
 
 # Versioning
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,11 @@ Begin by [importing the repository](https://github.com/new/import) into a global
   - Privacy: Public
 - Press "Begin Import"
 
-The repository contains a GitHub Action that will run and update from upstream at least once per hour, see `./.github/workflows/update-azure-devops-templates-from-upstream.yaml`.
+#### Keeping the repository up to date
+
+The repository contains a GitHub Action that will automatically run and update the `main` branch from upstream at least once per hour, see [`./.github/workflows/update-azure-devops-templates-from-upstream.yaml`](https://github.com/XenitAB/azure-devops-templates/blob/main/.github/workflows/update-azure-devops-templates-from-upstream.yaml).
+
+In order for this to run correctly, you need add a secret to your clone called `UPDATE_FROM_UPSTREAM_PAT`. This secret needs to be a Personal Access Token (PAT) with access to the `workflow` scope. For information on how to create a PAT [see here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). For more information about how to add a secret, [see here](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
 
 # Versioning
 


### PR DESCRIPTION
This fixes an issue where the automatic updating of the `main` branch fails due to changes in the `.workflows` folder (#108), since the default token does not have the `workflow` access.