### PR TITLE
Add logging at validation failure in plan stage

### DIFF
--- a/.github/workflows/terraform-docker.yaml
+++ b/.github/workflows/terraform-docker.yaml
@@ -92,8 +92,11 @@ jobs:
           if [[ "${{ inputs.VALIDATE_ENABLED }}" -eq "True" || "${{ inputs.VALIDATE_ENABLED }}" -eq "true" ]]; then
             make validate
             if [[ $(git status --porcelain) ]]; then
-              git diff
-              echo 'run make validate and commit changes' 1>&2
+              echo -e "Changed or untracked files found. Please run 'make validate' and then commit the changed and/or untracked files.\n" 1>&2
+              echo -e "\nOutput from 'git status':\n\n" 1>&2
+              git status
+              echo -e "\nOutput from 'git diff':\n\n" 1>&2
+              git --no-pager diff
               exit 1
             fi
           fi

--- a/terraform-docker/plan/main.yaml
+++ b/terraform-docker/plan/main.yaml
@@ -65,10 +65,10 @@ stages:
                     if [[ "${VALIDATE_ENABLED}" == "True" ]]; then
                       make validate
                       if [[ $(git status --porcelain) ]]; then
-                        printf "Changed or untracked files found. Please run 'make validate' and then commit the changed and/or untracked files.\n" 1>&2
-                        printf "\nOutput from 'git status':\n\n" 1>&2
+                        echo -e "Changed or untracked files found. Please run 'make validate' and then commit the changed and/or untracked files.\n" 1>&2
+                        echo -e "\nOutput from 'git status':\n\n" 1>&2
                         git status
-                        printf "\nOutput from 'git diff':\n\n" 1>&2
+                        echo -e "\nOutput from 'git diff':\n\n" 1>&2
                         git --no-pager diff
                         exit 1
                       fi

--- a/terraform-docker/plan/main.yaml
+++ b/terraform-docker/plan/main.yaml
@@ -65,8 +65,11 @@ stages:
                     if [[ "${VALIDATE_ENABLED}" == "True" ]]; then
                       make validate
                       if [[ $(git status --porcelain) ]]; then
-                        git diff
-                        echo 'run make validate and commit changes' 1>&2
+                        printf "Changed or untracked files found. Please run 'make validate' and then commit the changed and/or untracked files.\n" 1>&2
+                        printf "\nOutput from 'git status':\n\n" 1>&2
+                        git status
+                        printf "\nOutput from 'git diff':\n\n" 1>&2
+                        git --no-pager diff
                         exit 1
                       fi
                     fi


### PR DESCRIPTION
The background here is to cover the case that the .terraform.lock.hcl
file has been accidentaly removed from git. Since a new .terraform.lock.hcl
will have been generated by terraform init in that case, it will show up
as an untracked file in the output of git status. Before this fix, there was nothing in the logs that shows that the stage failed due to the presence of an untracked file.