### PR TITLE
Bump to gitops-promotion 1.0.0-pre2 for verification

### DIFF
--- a/gitops-v2/new/main.yaml
+++ b/gitops-v2/new/main.yaml
@@ -18,7 +18,7 @@ parameters:
     default: ""
   - name: gitopsPromotionTag
     type: string
-    default: "v0.0.6"
+    default: "v1.0.0-pre2"
   - name: awsServiceConnectionTemplate
     type: string
     default: ""

--- a/gitops-v2/promote/main.yaml
+++ b/gitops-v2/promote/main.yaml
@@ -7,7 +7,7 @@ parameters:
     default: ""
   - name: gitopsPromotionTag
     type: string
-    default: "v0.0.6"
+    default: "v1.0.0-pre2"
 
 stages:
   - stage: promote

--- a/gitops-v2/status/main.yaml
+++ b/gitops-v2/status/main.yaml
@@ -7,7 +7,7 @@ parameters:
     default: ""
   - name: gitopsPromotionTag
     type: string
-    default: "v0.0.6"
+    default: "v1.0.0-pre2"
 
 stages:
   - stage: status


### PR DESCRIPTION
Verifying that Azure DevOps provider still works after all the GitHub provider work.