### PR TITLE
Add manifest validation pipeline for Azure Devops

### DIFF
--- a/gitops-v2/README.md
+++ b/gitops-v2/README.md
@@ -47,6 +47,9 @@ the "gitops" repository. These three pipelines are responsible for creating the 
 one environment to another. The templates make heavy use of the [gitops-promotion](https://github.com/XenitAB/gitops-promotion)
 tool to execute the majority of logic.
 
+In addition to the gitops promotion pipelines mentioned above, the `./validate/main.yaml` can be used in the "gitops" repository
+to create a pipeline that validates the syntactical correctness of the manifests.
+
 ## Usage
 
 Create the build pipeline in the application repository. The `serviceName` is the name of the application.
@@ -176,6 +179,22 @@ resources:
 
 stages:
   - template: ./gitops-v2/promote/main.yaml@templates
+```
+
+validate.yaml
+
+```yaml
+trigger: none
+
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: XKS/azure-devops-templates
+      ref: refs/tags/2021.04.2
+
+stages:
+  - template: ./gitops-v2/validate/main.yaml@templates
 ```
 
 TBD - Repository configuration

--- a/gitops-v2/validate/main.yaml
+++ b/gitops-v2/validate/main.yaml
@@ -1,0 +1,48 @@
+parameters:
+  - name: poolVmImage
+    type: string
+    default: "ubuntu-18.04"
+  - name: poolName
+    type: string
+    default: ""
+  - name: binaries
+    type: object
+    default:
+      kustomize:
+        tag: "v4.5.1"
+        sha: "b8e16b303d9aa210d135710efb63f39ec15ae2a5fb5dedf38698f512f95cd2bd"
+
+stages:
+  - stage: validate
+    jobs:
+      - job: kustomize
+        pool:
+          ${{ if not(eq(parameters.poolName, '')) }}:
+            name: ${{ parameters.poolName }}
+          ${{ if not(eq(parameters.poolVmImage, '')) }}:
+            vmImage: ${{ parameters.poolVmImage }}
+        continueOnError: false
+        steps:
+          - bash: |
+              set -e
+              wget https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_TAG}/kustomize_${KUSTOMIZE_TAG}_linux_amd64.tar.gz
+              tar -xvf kustomize_v4.5.1_linux_amd64.tar.gz
+              DOWNLOAD_KUSTOMIZE_SHA=$(openssl sha1 -sha256 kustomize | awk '{print $2}')
+              if [[ "${KUSTOMIZE_SHA}" != "${DOWNLOAD_KUSTOMIZE_SHA}" ]]; then
+                  echo "Downloaded checksum (${DOWNLOAD_KUSTOMIZE_SHA}) for 'kustomize' does not match expected value: ${KUSTOMIZE_SHA}"
+                  exit 1
+              fi
+              # Go to all folders containing a kustomization.yaml file and run kustomize build
+              while IFS= read -r -d '' file; do
+                  dir=$(echo "$file" | sed -r 's|/[^/]+$||')
+                  cd "$dir"
+                  echo -e "\n======================================================================================" 1>&2
+                  echo "Running  'kustomize build .' in '$dir':" 1>&2
+                  echo "======================================================================================" 1>&2
+                  kustomize build .
+                  cd -
+              done < <(find . -type f -name 'kustomization.yaml' -print0)
+            displayName: "kustomize build"
+            env:
+              KUSTOMIZE_TAG: ${{ parameters.binaries.kustomize.tag }}
+              KUSTOMIZE_SHA: ${{ parameters.binaries.kustomize.sha }}

--- a/gitops-v2/validate/main.yaml
+++ b/gitops-v2/validate/main.yaml
@@ -35,12 +35,10 @@ stages:
               # Go to all folders containing a kustomization.yaml file and run kustomize build
               while read -r -d '' file; do
                   dir=$(dirname "$file")
-                  cd "$dir"
                   echo -e "\n======================================================================================" 1>&2
                   echo "Running  'kustomize build .' in '$dir':" 1>&2
                   echo "======================================================================================" 1>&2
-                  kustomize build .
-                  cd -
+                  kustomize build "$dir"
               done < <(find . -type f -name 'kustomization.yaml' -print0)
             displayName: "kustomize build"
             env:

--- a/gitops-v2/validate/main.yaml
+++ b/gitops-v2/validate/main.yaml
@@ -32,7 +32,7 @@ stages:
                   echo "Downloaded checksum (${DOWNLOAD_KUSTOMIZE_SHA}) for 'kustomize' does not match expected value: ${KUSTOMIZE_SHA}" 1>&2
                   exit 1
               fi
-              # Go to all folders containing a kustomization.yaml file and run kustomize build
+              # Run kustomize build for all folders containing a kustomization.yaml file
               while read -r -d '' file; do
                   dir=$(dirname "$file")
                   echo -e "\n======================================================================================" 1>&2

--- a/gitops-v2/validate/main.yaml
+++ b/gitops-v2/validate/main.yaml
@@ -29,12 +29,12 @@ stages:
               tar -xvf kustomize_v4.5.1_linux_amd64.tar.gz
               DOWNLOAD_KUSTOMIZE_SHA=$(openssl sha1 -sha256 kustomize | awk '{print $2}')
               if [[ "${KUSTOMIZE_SHA}" != "${DOWNLOAD_KUSTOMIZE_SHA}" ]]; then
-                  echo "Downloaded checksum (${DOWNLOAD_KUSTOMIZE_SHA}) for 'kustomize' does not match expected value: ${KUSTOMIZE_SHA}"
+                  echo "Downloaded checksum (${DOWNLOAD_KUSTOMIZE_SHA}) for 'kustomize' does not match expected value: ${KUSTOMIZE_SHA}" 1>&2
                   exit 1
               fi
               # Go to all folders containing a kustomization.yaml file and run kustomize build
-              while IFS= read -r -d '' file; do
-                  dir=$(echo "$file" | sed -r 's|/[^/]+$||')
+              while read -r -d '' file; do
+                  dir=$(dirname "$file")
                   cd "$dir"
                   echo -e "\n======================================================================================" 1>&2
                   echo "Running  'kustomize build .' in '$dir':" 1>&2


### PR DESCRIPTION
Today we don't have any protection against merging PRs with faulty manifests in the gitops repositories. This PR adds a pipeline that can be used for PR build validation in Azure Devops. The pipeline performs a kustomize build but can be further extended in the future, e,g, linting.