### PR TITLE
Update version of trivy to v0.29.2

### DIFF
--- a/gitops-v2/build/main.yaml
+++ b/gitops-v2/build/main.yaml
@@ -48,8 +48,8 @@ parameters:
         tag: "v1.18.0"
         sha: "f9bc9de12438b463ca84e77fde70b07b155d4da07ca21bc3f4354a62c6199db4"
       trivy:
-        tag: "v0.20.2"
-        sha: "38a6de48e21a34e0fa0d2cf63439c0afcbbae0e78fb3feada7a84a9cf6e7f60c"
+        tag: "v0.29.2"
+        sha: "d9d0fdb351dfea340e6621b2f9cbd4e1b86ecc83f05a9d31ce265839259c7576"
       horusec:
         tag: "v2.5.0"
         sha: "94bbfcb65db40d802b0c5b5b5a7f31bc89d4bd25ba6cbff3fa5debe3313d1b1f"

--- a/gitops-v2/build/main.yaml
+++ b/gitops-v2/build/main.yaml
@@ -152,9 +152,9 @@ stages:
               tar xzvf trivy_${TRIVY_TAG:1}_Linux-64bit.tar.gz
               chmod +x trivy
               # Run
-              ./trivy --reset --no-progress
-              ./trivy --exit-code 0 --no-progress --input ${IMAGE_ID}.tar
-              ./trivy --exit-code 1 --no-progress --ignore-unfixed --input ${IMAGE_ID}.tar
+              ./trivy image --reset --no-progress
+              ./trivy image --exit-code 0 --no-progress --input ${IMAGE_ID}.tar
+              ./trivy image --exit-code 1 --no-progress --ignore-unfixed --input ${IMAGE_ID}.tar
             displayName: Image scan
             continueOnError: ${{ parameters.imageScan.ignoreRuleViolations }}
             env:


### PR DESCRIPTION
In addition to updating version I've added the `image` sub command when running trivy.
If not including the sub command, trivy fails with error `FATAL	flag provided but not defined: -reset`