### PR TITLE
Disable shallow cloning in all Flux V2 promotion pipelines

### DIFF
--- a/gitops-v2/feature/feature.yaml
+++ b/gitops-v2/feature/feature.yaml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - checkout: self
         persistCredentials: true
+        fetchDepth: 0
         displayName: Get sources
       - bash: |
           set -e

--- a/gitops-v2/new/new.yaml
+++ b/gitops-v2/new/new.yaml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - checkout: self
         persistCredentials: true
+        fetchDepth: 0
         displayName: Get sources
       - bash: |
           set -e

--- a/gitops-v2/promote/main.yaml
+++ b/gitops-v2/promote/main.yaml
@@ -21,6 +21,7 @@ stages:
         steps:
           - checkout: self
             persistCredentials: true
+            fetchDepth: 0
             displayName: Get sources
           - bash: |
               git config --global user.email "azure-pipelines@${PROJECT_NAME}.${REPO_NAME}"

--- a/gitops-v2/status/main.yaml
+++ b/gitops-v2/status/main.yaml
@@ -22,6 +22,7 @@ stages:
         steps:
           - checkout: self
             persistCredentials: true
+            fetchDepth: 0
             displayName: Get sources
           - bash: |
               [ -z "$PR_BRANCH" ] && exit 0


### PR DESCRIPTION
Azure DevOps release has enabled shallow cloning by default. This breaks the GitOps promotion flow. Fix this by explicitly disabling shallow cloning.

https://learn.microsoft.com/en-us/azure/devops/release-notes/2022/sprint-209-update?tabs=yaml#do-not-sync-tags-when-fetching-a-git-repository