### PR TITLE
Added default value for postBuildJob

### DIFF
--- a/gitops-v2/build/main.yaml
+++ b/gitops-v2/build/main.yaml
@@ -25,6 +25,7 @@ parameters:
     default: []
   - name: postBuildJob
     type: jobList
+    default: []
   - name: preBuild
     type: stepList
     default: []


### PR DESCRIPTION
Was missing a default parameter for postBuildJob which made this mandatory to use