### PR TITLE
Add support for submodules

### DIFF
--- a/gitops-v2/build/main.yaml
+++ b/gitops-v2/build/main.yaml
@@ -62,6 +62,9 @@ parameters:
   - name: dependsOnStage
     type: object
     default: ["build"]
+  - name: subModules
+    type: boolean
+    default: false    
 
 stages:
   - stage: build
@@ -76,6 +79,8 @@ stages:
             vmImage: ${{ parameters.poolVmImage }}
         continueOnError: false
         steps:
+          - checkout: self
+            submodules: ${{ parameters.subModules }} 
           - bash: |
               set -e
               IMAGE_ID=${SERVICE_NAME}:${SOURCE_VERSION:0:7}

--- a/gitops-v2/build/main.yaml
+++ b/gitops-v2/build/main.yaml
@@ -25,6 +25,7 @@ parameters:
     default: []
   - name: postBuildJob
     type: jobList
+    default: []
   - name: preBuild
     type: stepList
     default: []

--- a/gitops-v2/build/main.yaml
+++ b/gitops-v2/build/main.yaml
@@ -62,7 +62,7 @@ parameters:
   - name: dependsOnStage
     type: object
     default: ["build"]
-  - name: subModules
+  - name: submodules
     type: boolean
     default: false    
 
@@ -80,7 +80,7 @@ stages:
         continueOnError: false
         steps:
           - checkout: self
-            submodules: ${{ parameters.subModules }} 
+            submodules: ${{ parameters.submodules }} 
           - bash: |
               set -e
               IMAGE_ID=${SERVICE_NAME}:${SOURCE_VERSION:0:7}


### PR DESCRIPTION
One of our feature teams has recently added submodules to our monolith repo. Pipelines based on this template fails now and then, but not always. Main difference we see from our old pipelines is "submodules: true" setting.