### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/push-image-acr.yaml
+++ b/.github/workflows/push-image-acr.yaml
@@ -77,16 +77,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Build and export
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           tags: ${{ inputs.image-name }}:latest
           outputs: type=docker,dest=/tmp/${{ inputs.image-name }}.tar
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ inputs.image-name }}
           path: /tmp/${{ inputs.image-name }}.tar
@@ -119,15 +119,15 @@ jobs:
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
           echo "::set-output name=sha_short::$SHA_SHORT"
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2.1.0
         with:
           registry: ${{ secrets[steps.creds_env.outputs.registry_login_server_env] }}
           username: ${{ secrets[steps.creds_env.outputs.registry_username_env] }}
           password: ${{ secrets[steps.creds_env.outputs.registry_password_env] }}
       - name: Download artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.image-name }}
           path: /tmp
@@ -151,8 +151,8 @@ jobs:
       - name: Short sha
         id: short_sha
         run: |
-            SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-            echo "::set-output name=sha_short::$SHA_SHORT"
+          SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
+          echo "::set-output name=sha_short::$SHA_SHORT"
       - name: Notify gitops-promotion workflow
         uses: peter-evans/repository-dispatch@v1
         with:

--- a/.github/workflows/terraform-docker.yaml
+++ b/.github/workflows/terraform-docker.yaml
@@ -8,7 +8,7 @@ on:
         required: false
         default: '["ubuntu-latest"]'
       opa_blast_radius:
-        description: 'OPA Blast Radius'
+        description: "OPA Blast Radius"
         required: false
         type: string
         default: "50"
@@ -63,7 +63,7 @@ jobs:
           echo "::set-output name=azure_creds_env::$AZURE_CREDS_ENV"
 
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@v1.4.6
         with:
           creds: ${{ secrets[steps.creds_env.outputs.azure_creds_env] }}
 
@@ -112,7 +112,7 @@ jobs:
 
       - name: Azure logout
         if: always()
-        uses: azure/CLI@v1
+        uses: azure/CLI@v1.0.7
         env:
           ENV: ${{ matrix.environments.name }}
         with:
@@ -140,7 +140,7 @@ jobs:
           echo "::set-output name=azure_creds_env::$AZURE_CREDS_ENV"
 
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@v1.4.6
         with:
           creds: ${{ secrets[steps.creds_env.outputs.azure_creds_env] }}
 
@@ -170,7 +170,7 @@ jobs:
 
       - name: Azure logout
         if: always()
-        uses: azure/CLI@v1
+        uses: azure/CLI@v1.0.7
         env:
           ENV: ${{ matrix.environments.name }}
         with:

--- a/.github/workflows/update-azure-devops-templates-from-upstream.yaml
+++ b/.github/workflows/update-azure-devops-templates-from-upstream.yaml
@@ -18,7 +18,7 @@ jobs:
           app_id: ${{ secrets.UPDATE_FROM_UPSTREAM_APP_ID }}
           private_key: ${{ secrets.UPDATE_FROM_UPSTREAM_PRIVATE_KEY }}
       - name: Update from upstream
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         # this makes no sense to run on the main repository, and it might not even work there
         if: ${{ env.GITHUB_REPOSITORY != 'XenitAB/azure-devops-templates' }}
         with:


### PR DESCRIPTION
Github are deprecating old nodejs versions that many github actions are built on.
So we need to patch to follow along.