### PR TITLE
Support OIDC by upgrading the AZCLI task to v2

### DIFF
--- a/terraform-docker/apply/main.yaml
+++ b/terraform-docker/apply/main.yaml
@@ -68,11 +68,12 @@ stages:
                         artifact: "${{ env.name }}.enc"
                         path: $(Build.Repository.LocalPath)/${{ parameters.terraformFolder }}/.terraform/plans
 
-                    - task: AzureCLI@1
+                    - task: AzureCLI@2
                       displayName: "Apply"
                       inputs:
                         azureSubscription: ${{ format(parameters.azureSubscriptionTemplate, env.name) }}
                         addSpnToEnvironment: true
+                        scriptType: bash
                         scriptLocation: inlineScript
                         inlineScript: |
                           set -e

--- a/terraform-docker/plan/main.yaml
+++ b/terraform-docker/plan/main.yaml
@@ -45,10 +45,11 @@ stages:
                       awsRegion: ${{ parameters.awsRegion }}
                       awsServiceConnection: ${{ format(parameters.awsServiceConnectionTemplate, env.name) }}
 
-              - task: AzureCLI@1
+              - task: AzureCLI@2
                 inputs:
                   azureSubscription: ${{ format(parameters.azureSubscriptionTemplate, env.name) }}
                   addSpnToEnvironment: true
+                  scriptType: bash
                   scriptLocation: inlineScript
                   inlineScript: |
                     set -e


### PR DESCRIPTION
We have the need to use OIDC (Workload identity federation tokens) instead of secrets.
Bumped the version of AzureCLI to v2 and added the new required `scriptType` setting.

The OIDC token will be present as the `idToken` environment variable.

https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/azure-cli-v2?view=azure-pipelines